### PR TITLE
🕶  New script transpilation watcher 

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (gulp, swig) {
   });
 
   require('@gilt-tech/swig-zk')(gulp, swig);
-  require('@gilt-tech/swig-transform-jsx')(gulp, swig);
+  require('@gilt-tech/swig-transpile-scripts')(gulp, swig);
 
   var path = require('path'),
     spawn = require('child_process').spawn,
@@ -102,7 +102,7 @@ module.exports = function (gulp, swig) {
     });
   }
 
-  gulp.task('run', ['zk', 'watch-jsx'], function (cb) {
+  gulp.task('run', ['zk', 'watch-scripts'], function (cb) {
 
     var errors;
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,16 @@
       "name": "Andrew Powell",
       "email": "powella@gilt.com",
       "url": "https://github.com/shellscape/"
+    },
+    {
+      "name": "Nick Rogers",
+      "email": "nrogers@gilt.com",
+      "url": "https://github.com/njprrogers/"
+    },
+    {
+      "name": "Federico Giovagnoli",
+      "email": "fgiovagnoli@gilt.com",
+      "url": "https://github.com/Meesayen/"
     }
   ],
   "licenses": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-run",
   "description": "",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/gilt/gilt-swig-run",
   "keywords": [
     "gulp",
@@ -42,7 +42,7 @@
     "underscore": "*",
 
     "@gilt-tech/swig-zk": "*",
-    "@gilt-tech/swig-transform-jsx": "*"
+    "@gilt-tech/swig-transpile-scripts": "^1.0.0"
   },
   "devDependencies": {},
   "main": "index.js",


### PR DESCRIPTION
Changed watcher from JSX only transform to full script transpilation. See [here](https://github.com/gilt/gilt-swig-assets/pull/36) for more info.