### PR TITLE
🛠  Bump node version + benefits

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ module.exports = function (gulp, swig) {
   });
 
   require('@gilt-tech/swig-zk')(gulp, swig);
-  require('@gilt-tech/swig-transpile-scripts')(gulp, swig);
 
   var path = require('path'),
     spawn = require('child_process').spawn,
@@ -102,7 +101,8 @@ module.exports = function (gulp, swig) {
     });
   }
 
-  gulp.task('run', ['zk', 'watch-scripts'], function (cb) {
+  // NOTE: Running transpile-scripts once, to produce artifacts in app/ folder
+  gulp.task('run', ['transpile-scripts', 'zk', 'watch-scripts'], function (cb) {
 
     var errors;
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (gulp, swig) {
 
   require('@gilt-tech/swig-zk')(gulp, swig);
 
-  if (!swig.pkg.tasks['transpile-scripts']) {
+  if (!swig.tasks['transpile-scripts']) {
     require('@gilt-tech/swig-transpile-scripts')(gulp, swig);
   }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ module.exports = function (gulp, swig) {
 
   require('@gilt-tech/swig-zk')(gulp, swig);
 
+  if (!swig.pkg.tasks['transpile-scripts']) {
+    require('@gilt-tech/swig-transpile-scripts')(gulp, swig);
+  }
+
   var path = require('path'),
     spawn = require('child_process').spawn,
     fs = require('fs'),

--- a/lib/command-forever
+++ b/lib/command-forever
@@ -16,8 +16,8 @@ export GILT_ENV=development;
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 FOREVER="$DIR/../node_modules/.bin/forever"
 source ~/.nvm/nvm.sh;
-nvm use 5;
-node "$FOREVER" start -c "node --harmony --harmony-proxies" app.js
+nvm use 6;
+node "$FOREVER" start -c "node" app.js
 node "$FOREVER" logs app.js -f -n 1
 # forever start -c "node --harmony --harmony-proxies" app.js
 # forever logs app.js -f -n 1

--- a/lib/command-node
+++ b/lib/command-node
@@ -14,6 +14,6 @@
 
 export GILT_ENV=development;
 source ~/.nvm/nvm.sh;
-nvm use 5;
+nvm use 6;
 echo ""
-node --harmony --harmony-proxies $@ app;
+node $@ app;

--- a/package.json
+++ b/package.json
@@ -45,12 +45,11 @@
     }
   ],
   "engines": {
-    "node": ">= 5.x"
+    "node": ">= 6.x"
   },
   "dependencies": {
     "forever": "^0.15.1",
     "underscore": "*",
-
     "@gilt-tech/swig-zk": "*",
     "@gilt-tech/swig-transpile-scripts": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-run",
   "description": "",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/gilt/gilt-swig-run",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Switched from node 5 to node 6.
Made transpile-scripts task to run at least once after launching swig-run.