### PR TITLE
✨  Fixed swig-zk node 6 issues

### DIFF
--- a/lib/swig-zk/index.js
+++ b/lib/swig-zk/index.js
@@ -20,7 +20,7 @@ module.exports = function (gulp, swig) {
     fs = require('fs'),
     thunkify = require('thunkify'),
     co = require('co'),
-    sh = require('co-sh'),
+    run = require('co-run'),
     read = require('co-read'),
     zkDir = '/web/zookeeper',
     zkPid = path.join(zkDir, '/var/zookeeper_server.pid'),
@@ -63,7 +63,7 @@ module.exports = function (gulp, swig) {
       return;
     }
 
-    var proc = yield sh[zkSh + ' ' + command]();
+    var proc = yield run(zkSh + ' ' + command);
 
     while (buffer = yield read(proc.stdout)) {
       swig.log(swig.log.padding + ' ' + buffer.toString().grey);

--- a/lib/swig-zk/package.json
+++ b/lib/swig-zk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-zk",
   "description": "A swig task that ensures zookeeper is running.",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "homepage": "https://github.com/gilt/gilt-swig-run",
   "keywords": [
     "gulp",
@@ -38,11 +38,11 @@
     "node": ">= 0.12.x"
   },
   "dependencies": {
-    "co": "3.x",
-    "co-sh": "*",
-    "co-read": "*",
-    "thunkify": "*",
-    "underscore": "*"
+    "co": "^3.1.0",
+    "co-read": "^0.1.1",
+    "co-run": "^1.0.0",
+    "thunkify": "^2.1.2",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {},
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-run",
   "description": "",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/gilt/gilt-swig-run",
   "keywords": [
     "gulp",
@@ -50,7 +50,7 @@
   "dependencies": {
     "forever": "^0.15.1",
     "underscore": "*",
-    "@gilt-tech/swig-zk": "*",
+    "@gilt-tech/swig-zk": "^1.0.0",
     "@gilt-tech/swig-transpile-scripts": "^1.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
`co-sh` was using a deprecated `Proxy.create` API, which doesn't work on node v6 and above.

I switched to `co-run`, which should do the exact same thing as `co-sh` but without the fancy `Proxy` thing (it was a weird implementation anyway)

I also fixed versions on every dependencies, to make it less indeterministic.